### PR TITLE
Add mixin for API object retrieval

### DIFF
--- a/transip/mixins.py
+++ b/transip/mixins.py
@@ -23,6 +23,30 @@ from transip import TransIP
 from transip.base import ApiObject
 
 
+class GetMixin:
+    """Retrieve an single ApiObject.
+
+    Derived class must define ``_resp_get_attr``.
+
+    ``_resp_get_attr``: The response attribute which contains the object
+    """
+    client: TransIP
+    _obj_cls: Optional[Type[ApiObject]]
+    _path: str
+
+    _resp_get_attr: Optional[str] = None
+
+    def get(self, id: str, **kwargs) -> Optional[Type[ApiObject]]:
+        if self._obj_cls or self._path or self._resp_get_attr:
+            path: str = "{path}/{id}".format(
+                path=self._path,
+                id=id
+            )
+            obj: Type[ApiObject] = self.client.get(path)[self._resp_get_attr]
+            return obj
+        return None
+
+
 class ListMixin:
     """Retrieve a list of ApiObjects.
 

--- a/transip/v6/services/domain.py
+++ b/transip/v6/services/domain.py
@@ -20,12 +20,14 @@
 from typing import Optional, Type
 
 from transip.base import ApiService, ApiObject
-from transip.mixins import ListMixin
+from transip.mixins import GetMixin, ListMixin
 from transip.v6.objects.domain import Domain
 
 
-class DomainService(ListMixin, ApiService):
+class DomainService(GetMixin, ListMixin, ApiService):
 
     _path: str = "/domains"
     _obj_cls: Optional[Type[ApiObject]] = Domain
+
     _resp_list_attr: str = "domains"
+    _resp_get_attr: str = "domain"

--- a/transip/v6/services/vps.py
+++ b/transip/v6/services/vps.py
@@ -20,12 +20,14 @@
 from typing import Optional, Type
 
 from transip.base import ApiService, ApiObject
-from transip.mixins import ListMixin
+from transip.mixins import GetMixin, ListMixin
 from transip.v6.objects.vps import Vps
 
 
-class VpsService(ListMixin, ApiService):
+class VpsService(GetMixin, ListMixin, ApiService):
 
     _path: str = "/vps"
     _obj_cls: Optional[Type[ApiObject]] = Vps
+
     _resp_list_attr: str = "vpss"
+    _resp_get_attr: str = "vps"


### PR DESCRIPTION
Add `transip.mixins.GetMixin` to allow the retrieval of a single object from the TransIP API.

This object also adds the `GetMixin` to both existing services (_`transip.v6.services.domain.DomainService` and `transip.v6.services.vps.VpsService`_).
