### PR TITLE
Fix GetMixin to let it return an ApiObject instead of a dictionary

### DIFF
--- a/transip/mixins.py
+++ b/transip/mixins.py
@@ -42,7 +42,9 @@ class GetMixin:
                 path=self._path,
                 id=id
             )
-            obj: Type[ApiObject] = self.client.get(path)[self._resp_get_attr]
+            obj: Type[ApiObject] = self._obj_cls(  # type: ignore
+                self.client.get(path)[self._resp_get_attr]
+            )
             return obj
         return None
 


### PR DESCRIPTION
Fix `transip.mixins.GetMixin` by letting it return a `transip.base.ApiObject` instead of a dictionary.
