### PR TITLE
Add InvoiceService to retrieve and list invoices

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -92,6 +92,26 @@ object by its name::
 
     >>> client.domains.delete('transipdemonstratie.nl')
 
+Invoices
+--------
+
+Using the
+:class:`InvoiceService <transip.v6.services.InvoiceService>`
+service we can retrieve all invoices in your TransIP account in the form of a
+:class:`Invoice <transip.v6.objects.Invoice>` object::
+
+    >>> invoices = client.invoices.list()
+    >>> for invoice in invoices:
+    ...     print(invoice)
+    <class 'transip.v6.objects.invoice.Invoice'> => {'invoiceNumber': 'F0000.1911.0000.0004', 'creationDate': '2020-01-01', 'payDate': '2020-01-01', 'dueDate': '2020-02-01', 'invoiceStatus': 'waitsforpayment', 'currency': 'EUR', 'totalAmount': 1000, 'totalAmountInclVat': 1240}
+
+We could also retrieve a single :class:`Invoice <transip.v6.objects.Invoice>`
+object by its invoice number::
+
+    >>> invoice = client.invoices.get('F0000.1911.0000.0004')
+    >>> print(f"{invoice.invoiceNumber} has status '{invoice.invoiceStatus}'")
+    F0000.1911.0000.0004 has status 'waitsforpayment'
+
 VPSs
 ----
 

--- a/tests/services/test_invoices.py
+++ b/tests/services/test_invoices.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Roald Nefs <info@roaldnefs.com>
+#
+# This file is part of python-transip.
+
+# python-transip is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# python-transip is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Type, List
+import responses  # type: ignore
+
+from transip import TransIP
+from transip.v6.objects import Invoice
+
+
+@responses.activate
+def test_invoices_list(transip_minimal_client: Type[TransIP]) -> None:
+    responses.add(
+        responses.GET,
+        "https://api.transip.nl/v6/invoices",
+        json={
+            "invoices": [
+                {
+                    "invoiceNumber": "F0000.1911.0000.0004",
+                    "creationDate": "2020-01-01",
+                    "payDate": "2020-01-01",
+                    "dueDate": "2020-02-01",
+                    "invoiceStatus": "waitsforpayment",
+                    "currency": "EUR",
+                    "totalAmount": 1000,
+                    "totalAmountInclVat": 1240
+                }
+            ]
+        },
+        status=200,
+    )
+    
+    invoices: List[Type[Invoice]] = transip_minimal_client.invoices.list()
+    invoice: Type[Invoice] = invoices[0] 
+    assert len(invoices) == 1
+    assert invoice.get_id() == "F0000.1911.0000.0004"  # type: ignore
+
+
+@responses.activate
+def test_invoices_get(transip_minimal_client: Type[TransIP]) -> None:
+    responses.add(
+        responses.GET,
+        "https://api.transip.nl/v6/invoices/F0000.1911.0000.0004",
+        json={
+            "invoice": {
+                "invoiceNumber": "F0000.1911.0000.0004",
+                "creationDate": "2020-01-01",
+                "payDate": "2020-01-01",
+                "dueDate": "2020-02-01",
+                "invoiceStatus": "waitsforpayment",
+                "currency": "EUR",
+                "totalAmount": 1000,
+                "totalAmountInclVat": 1240
+            }
+        },
+        status=200,
+    )
+    
+    invoice_id: str = "F0000.1911.0000.0004"
+    invoice: Type[Invoice] = transip_minimal_client.invoices.get(invoice_id)
+    assert invoice.get_id() == "F0000.1911.0000.0004"  # type: ignore

--- a/transip/__init__.py
+++ b/transip/__init__.py
@@ -68,6 +68,9 @@ class TransIP:
             services.AvailabilityZoneService(self)  # type: ignore
         )
         self.domains: Type[Any] = services.DomainService(self)  # type: ignore
+        self.invoices: Type[Any] = (
+            services.InvoiceService(self)  # type: ignore
+        )
         self.ssh_keys: Type[Any] = services.SshKeyService(self)  # type: ignore
         self.vpss: Type[Any] = services.VpsService(self)  # type: ignore
 

--- a/transip/v6/objects/invoice.py
+++ b/transip/v6/objects/invoice.py
@@ -17,8 +17,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from transip.v6.objects.availability_zone import AvailabilityZone  # noqa: 401
-from transip.v6.objects.invoice import Invoice  # noqa: 401
-from transip.v6.objects.domain import Domain  # noqa: 401
-from transip.v6.objects.ssh_key import SshKey  # noqa: 401
-from transip.v6.objects.vps import Vps  # noqa: 401
+from transip.base import ApiObject
+
+
+class Invoice(ApiObject):
+
+    _id_attr: str = "invoiceNumber"

--- a/transip/v6/services/__init__.py
+++ b/transip/v6/services/__init__.py
@@ -19,5 +19,6 @@
 
 from transip.v6.services.availability_zone import AvailabilityZoneService  # noqa: 401
 from transip.v6.services.domain import DomainService  # noqa: 401
+from transip.v6.services.invoice import InvoiceService  # noqa: 401
 from transip.v6.services.ssh_key import SshKeyService  # noqa: 401
 from transip.v6.services.vps import VpsService  # noqa: 401

--- a/transip/v6/services/invoice.py
+++ b/transip/v6/services/invoice.py
@@ -17,8 +17,17 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from transip.v6.objects.availability_zone import AvailabilityZone  # noqa: 401
-from transip.v6.objects.invoice import Invoice  # noqa: 401
-from transip.v6.objects.domain import Domain  # noqa: 401
-from transip.v6.objects.ssh_key import SshKey  # noqa: 401
-from transip.v6.objects.vps import Vps  # noqa: 401
+from typing import Optional, Type
+
+from transip.base import ApiService, ApiObject
+from transip.mixins import GetMixin, ListMixin
+from transip.v6.objects.invoice import Invoice
+
+
+class InvoiceService(GetMixin, ListMixin, ApiService):
+
+    _path: str = "/invoices"
+    _obj_cls: Optional[Type[ApiObject]] = Invoice
+
+    _resp_list_attr: str = "invoices"
+    _resp_get_attr: str = "invoice"


### PR DESCRIPTION
Add `transip.v6.services.InvoiceService` and corresponding object `transip.v6.objects.Invoice` to retrieve a single invoice by its invoice number or a list of all invoices in the TransIP account.