### PR TITLE
Add initial CreateMixin

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -114,6 +114,20 @@ single :class:`Domain <transip.v6.services.domain.Domain>` object by its name::
     <class 'transip.v6.services.domain.DnsEntry'> => {'name': 'www', 'expire': 86400, 'type': 'CNAME', 'content': '@'}
     <class 'transip.v6.services.domain.DnsEntry'> => {'name': '_dmarc', 'expire': 86400, 'type': 'TXT', 'content': 'v=DMARC1; p=none;'}
 
+
+It's also possible to create a new DNS entry for a single
+:class:`Domain <transip.v6.services.domain.Domain>`::
+
+    >>> domain = client.domains.get('transipdemonstratie.nl')
+    >>> dns_entry_data = {
+    ...     "name": "www",
+    ...     "expire": 86400,
+    ...     "type": "A",
+    ...     "content": "127.0.0.1"
+    ... }
+    >>> domain.dns.create(dns_entry_data)
+
+
 Domain Contacts
 ***************
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,13 @@ from typing import Type
 from transip import TransIP
 
 
+@pytest.fixture(scope="class")
+def minimal_client_class(request):
+    request.cls.client = TransIP(
+        access_token="access_token"
+    )
+
+
 @pytest.fixture
 def transip_minimal_client() -> TransIP:
     return TransIP(

--- a/tests/fixtures/contacts_list.json
+++ b/tests/fixtures/contacts_list.json
@@ -1,0 +1,20 @@
+{
+    "contacts": [
+        {
+            "type": "registrant",
+            "firstName": "John",
+            "lastName": "Doe",
+            "companyName": "Example B.V.",
+            "companyKvk": "83057825",
+            "companyType": "BV",
+            "street": "Easy street",
+            "number": "12",
+            "postalCode": "1337 XD",
+            "city": "Leiden",
+            "phoneNumber": "+31 715241919",
+            "faxNumber": "+31 715241919",
+            "email": "example@example.com",
+            "country": "nl"
+        }
+    ]
+}

--- a/tests/fixtures/dns_create.json
+++ b/tests/fixtures/dns_create.json
@@ -1,0 +1,8 @@
+{
+    "dnsEntry": {
+        "name": "www",
+        "expire": 86400,
+        "type": "A",
+        "content": "127.0.0.1"
+    }
+}

--- a/tests/fixtures/dns_list.json
+++ b/tests/fixtures/dns_list.json
@@ -1,0 +1,10 @@
+{
+    "dnsEntries": [
+        {
+            "name": "www",
+            "expire": 86400,
+            "type": "A",
+            "content": "127.0.0.1"
+        }
+    ]
+}

--- a/tests/fixtures/domains_get.json
+++ b/tests/fixtures/domains_get.json
@@ -1,0 +1,17 @@
+{
+    "domain": {
+        "name": "example.com",
+        "authCode": "kJqfuOXNOYQKqh/jO4bYSn54YDqgAt1ksCe+ZG4Ud4nfpzw8qBsfR2JqAj7Ce12SxKcGD09v+yXd6lrm",
+        "isTransferLocked": false,
+        "registrationDate": "2016-01-01",
+        "renewalDate": "2020-01-01",
+        "isWhitelabel": false,
+        "cancellationDate": "2020-01-01 12:00:00",
+        "cancellationStatus": "signed",
+        "isDnsOnly": false,
+        "tags": [
+            "customTag",
+            "anotherTag"
+        ]
+    }
+}

--- a/tests/fixtures/nameservers_list.json
+++ b/tests/fixtures/nameservers_list.json
@@ -1,0 +1,9 @@
+{
+    "nameservers": [
+        {
+            "hostname": "ns0.transip.nl",
+            "ipv4": "",
+            "ipv6": ""
+        }
+    ]
+}

--- a/tests/services/test_domains.py
+++ b/tests/services/test_domains.py
@@ -17,188 +17,99 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Type, List
 import responses  # type: ignore
+import unittest
+import pytest
+
+from typing import Type, List, Dict, Any, Union
 
 from transip import TransIP
 from transip.v6.services.domain import (
     Domain, WhoisContact, Nameserver, DnsEntry
 )
+from tests.utils import load_fixture
 
 
-@responses.activate
-def test_domains_get(transip_minimal_client: Type[TransIP]) -> None:
-    responses.add(
-        responses.GET,
-        "https://api.transip.nl/v6/domains/example.com",
-        json={
-            "domain": {
-                "name": "example.com",
-                "authCode": "kJqfuOXNOYQKqh/jO4bYSn54YDqgAt1ksCe+ZG4Ud4nfpzw8qBsfR2JqAj7Ce12SxKcGD09v+yXd6lrm",
-                "isTransferLocked": False,
-                "registrationDate": "2016-01-01",
-                "renewalDate": "2020-01-01",
-                "isWhitelabel": False,
-                "cancellationDate": "2020-01-01 12:00:00",
-                "cancellationStatus": "signed",
-                "isDnsOnly": False,
-                "tags": [
-                    "customTag",
-                    "anotherTag"
-                ]
-            }
-        },
-        status=200,
-    )
+@pytest.mark.usefixtures("minimal_client_class")
+class DomainsTest(unittest.TestCase):
+    """Test the DomainService."""
 
-    domain: Type[Domain] = transip_minimal_client.domains.get("example.com")
-    assert domain.get_id() == "example.com"  # type: ignore
+    client: Type[TransIP]
 
-@responses.activate
-def test_domains_contacts_list(transip_minimal_client: Type[TransIP]) -> None:
-    responses.add(
-        responses.GET,
-        "https://api.transip.nl/v6/domains/example.com",
-        json={
-            "domain": {
-                "name": "example.com",
-                "authCode": "kJqfuOXNOYQKqh/jO4bYSn54YDqgAt1ksCe+ZG4Ud4nfpzw8qBsfR2JqAj7Ce12SxKcGD09v+yXd6lrm",
-                "isTransferLocked": False,
-                "registrationDate": "2016-01-01",
-                "renewalDate": "2020-01-01",
-                "isWhitelabel": False,
-                "cancellationDate": "2020-01-01 12:00:00",
-                "cancellationStatus": "signed",
-                "isDnsOnly": False,
-                "tags": [
-                    "customTag",
-                    "anotherTag"
-                ]
-            }
-        },
-        status=200,
-    )
-    responses.add(
-        responses.GET,
-        "https://api.transip.nl/v6/domains/example.com/contacts",
-        json={
-            "contacts": [
-                {
-                "type": "registrant",
-                "firstName": "John",
-                "lastName": "Doe",
-                "companyName": "Example B.V.",
-                "companyKvk": "83057825",
-                "companyType": "BV",
-                "street": "Easy street",
-                "number": "12",
-                "postalCode": "1337 XD",
-                "city": "Leiden",
-                "phoneNumber": "+31 715241919",
-                "faxNumber": "+31 715241919",
-                "email": "example@example.com",
-                "country": "nl"
-                }
+    def setUp(self):
+        # Setup mocked responses for the /domains endpoint
+        responses.add(
+            responses.GET, "https://api.transip.nl/v6/domains/example.com",
+            json=load_fixture("domains_get.json"), status=200,
+            content_type='application/json',
+        )
+        responses.add(
+            responses.GET,
+            "https://api.transip.nl/v6/domains/example.com/contacts",
+            json=load_fixture("contacts_list.json"), status=200,
+            content_type='application/json',
+        )
+        responses.add(
+            responses.GET,
+            "https://api.transip.nl/v6/domains/example.com/nameservers",
+            json=load_fixture("nameservers_list.json"), status=200,
+            content_type='application/json',
+        )
+        responses.add(
+            responses.GET, "https://api.transip.nl/v6/domains/example.com/dns",
+            json=load_fixture("dns_list.json"), status=200,
+            content_type='application/json',
+        )
+        responses.add(
+            responses.POST, "https://api.transip.nl/v6/domains/example.com/dns",
+            status=201, content_type='application/json',
+            match=[
+                responses.json_params_matcher(load_fixture("dns_create.json")),
             ]
-        },
-        status=200,
     )
 
-    domain: Type[Domain] = transip_minimal_client.domains.get("example.com")
-    contacts: List[Type[Domain]] = domain.contacts.list()  # type: ignore
-    contact: Type[Domain] = contacts[0]
-    assert len(contacts) == 1
-    assert contact.companyName == "Example B.V."  # type: ignore
+    @responses.activate
+    def test_get(self) -> None:
+        domain: Type[Domain] = self.client.domains.get("example.com")
 
+        assert domain.get_id() == "example.com"  # type: ignore
 
-@responses.activate
-def test_domains_nameservers_list(transip_minimal_client: Type[TransIP]) -> None:
-    responses.add(
-        responses.GET,
-        "https://api.transip.nl/v6/domains/example.com",
-        json={
-            "domain": {
-                "name": "example.com",
-                "authCode": "kJqfuOXNOYQKqh/jO4bYSn54YDqgAt1ksCe+ZG4Ud4nfpzw8qBsfR2JqAj7Ce12SxKcGD09v+yXd6lrm",
-                "isTransferLocked": False,
-                "registrationDate": "2016-01-01",
-                "renewalDate": "2020-01-01",
-                "isWhitelabel": False,
-                "cancellationDate": "2020-01-01 12:00:00",
-                "cancellationStatus": "signed",
-                "isDnsOnly": False,
-                "tags": [
-                    "customTag",
-                    "anotherTag"
-                ]
-            }
-        },
-        status=200,
-    )
-    responses.add(
-        responses.GET,
-        "https://api.transip.nl/v6/domains/example.com/nameservers",
-        json={
-            "nameservers": [
-                {
-                    "hostname": "ns0.transip.nl",
-                    "ipv4": "",
-                    "ipv6": ""
-                }
-            ]
-        },
-        status=200,
-    )
+    @responses.activate
+    def test_contacts_list(self) -> None:
+        domain: Type[Domain] = self.client.domains.get("example.com")
+        contacts: List[Type[Domain]] = domain.contacts.list()  # type: ignore
+        contact: Type[Domain] = contacts[0]
 
-    domain: Type[Domain] = transip_minimal_client.domains.get("example.com")
-    nameservers: List[Type[Nameserver]] = domain.nameservers.list()  # type: ignore
-    nameserver: Type[Nameserver] = nameservers[0]
-    assert len(nameservers) == 1
-    assert nameserver.get_id() == "ns0.transip.nl"  # type: ignore
+        assert len(contacts) == 1
+        assert contact.companyName == "Example B.V."  # type: ignore
 
+    @responses.activate
+    def test_nameservers_list(self) -> None:
+        domain: Type[Domain] = self.client.domains.get("example.com")
+        nameservers: List[Type[Nameserver]] = domain.nameservers.list()  # type: ignore
+        nameserver: Type[Nameserver] = nameservers[0]
 
-@responses.activate
-def test_domains_dns_list(transip_minimal_client: Type[TransIP]) -> None:
-    responses.add(
-        responses.GET,
-        "https://api.transip.nl/v6/domains/example.com",
-        json={
-            "domain": {
-                "name": "example.com",
-                "authCode": "kJqfuOXNOYQKqh/jO4bYSn54YDqgAt1ksCe+ZG4Ud4nfpzw8qBsfR2JqAj7Ce12SxKcGD09v+yXd6lrm",
-                "isTransferLocked": False,
-                "registrationDate": "2016-01-01",
-                "renewalDate": "2020-01-01",
-                "isWhitelabel": False,
-                "cancellationDate": "2020-01-01 12:00:00",
-                "cancellationStatus": "signed",
-                "isDnsOnly": False,
-                "tags": [
-                    "customTag",
-                    "anotherTag"
-                ]
-            }
-        },
-        status=200,
-    )
-    responses.add(
-        responses.GET,
-        "https://api.transip.nl/v6/domains/example.com/dns",
-        json={
-            "dnsEntries": [
-                {
-                    "name": "www",
-                    "expire": 86400,
-                    "type": "A",
-                    "content": "127.0.0.1"
-                }
-            ]
-        },
-        status=200,
-    )
+        assert len(nameservers) == 1
+        assert nameserver.get_id() == "ns0.transip.nl"  # type: ignore
 
-    domain: Type[Domain] = transip_minimal_client.domains.get("example.com")
-    entries: List[Type[DnsEntry]] = domain.dns.list()  # type: ignore
-    entry: Type[DnsEntry] = entries[0]
-    assert len(entries) == 1
-    assert entry.name == "www"  # type: ignore
+    @responses.activate
+    def test_dns_list(self) -> None:
+        domain: Type[Domain] = self.client.domains.get("example.com")
+        entries: List[Type[DnsEntry]] = domain.dns.list()  # type: ignore
+        entry: Type[DnsEntry] = entries[0]
+
+        assert len(entries) == 1
+        assert entry.name == "www"  # type: ignore
+
+    @responses.activate
+    def test_dns_create(self) -> None:
+        dns_entry_data: Dict[str, Union[str, int]] = {
+            "name": "www",
+            "expire": 86400,
+            "type": "A",
+            "content": "127.0.0.1"
+        }
+        domain: Type[Domain] = self.client.domains.get("example.com")
+        domain.dns.create(dns_entry_data)  # type: ignore
+
+        assert len(responses.calls) == 2

--- a/tests/services/test_ssh_keys.py
+++ b/tests/services/test_ssh_keys.py
@@ -17,8 +17,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Type, List
+from typing import Type, List, Tuple, Any, Dict
 import responses  # type: ignore
+import json
 
 from transip import TransIP
 from transip.v6.services.ssh_key import SshKey
@@ -82,3 +83,25 @@ def test_ssh_keys_delete(transip_minimal_client: Type[TransIP]) -> None:
         transip_minimal_client.ssh_keys.delete(ssh_key_id)
     except Exception as exc:
         assert False, f"'transip.TransIP.ssh_keys.delete' raised an exception {exc}"
+
+
+@responses.activate
+def test_ssh_keys_create(transip_minimal_client: Type[TransIP]) -> None:
+    ssh_key_data: Dict[str, str] = {
+        "sshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDf2pxWX/yhUBDyk2LPhvRtI0LnVO8PyR5Zt6AHrnhtLGqK+8YG9EMlWbCCWrASR+Q1hFQG example",
+        "description": "Jim key"
+    }
+
+    responses.add(
+        responses.POST,
+        "https://api.transip.nl/v6/ssh-keys",
+        status=201,
+        content_type='application/json',
+        match=[
+            responses.json_params_matcher(ssh_key_data),
+        ]
+    )
+
+    transip_minimal_client.ssh_keys.create(ssh_key_data)
+
+    assert len(responses.calls) == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 Roald Nefs <info@roaldnefs.com>
+# Copyright (C) 2021 Roald Nefs <info@roaldnefs.com>
 #
 # This file is part of python-transip.
 
@@ -17,28 +17,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Optional, Type
-
-from transip.base import ApiService, ApiObject
-from transip.mixins import (
-    GetMixin, DeleteMixin, ListMixin, CreateMixin, CreateAttrsTuple
-)
+from typing import Any
+import json
+import os
 
 
-class SshKey(ApiObject):
-
-    _id_attr: str = "id"
-
-
-class SshKeyService(GetMixin, CreateMixin, DeleteMixin, ListMixin, ApiService):
-
-    _path: str = "/ssh-keys"
-    _obj_cls: Optional[Type[ApiObject]] = SshKey
-
-    _resp_list_attr: str = "sshKeys"
-    _resp_get_attr: str = "sshKey"
-
-    _create_attrs: Optional[CreateAttrsTuple] = (
-        ("sshKey",),  # required
-        ("description",)  # optional
+def load_fixture(path) -> Any:
+    """Load a JSON fixture from the fixtures directory."""
+    fixtures: str = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "fixtures"
     )
+    with open(os.path.join(fixtures, path)) as fixture:
+        return json.load(fixture)

--- a/transip/mixins.py
+++ b/transip/mixins.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Type
+from typing import Optional, List, Type, Dict, Any
 
 from transip import TransIP
 from transip.base import ApiObject
@@ -76,3 +76,19 @@ class ListMixin:
             for obj in self.client.get(self.path)[self._resp_list_attr]:
                 objs.append(self._obj_cls(self, obj))  # type: ignore
         return objs
+
+
+class CreateMixin:
+    """
+    Create a new ApiObject.
+    """
+
+    client: TransIP
+    path: str
+
+    def create(self, data: Optional[Dict[str, Any]]=None, **kwargs):
+        if data is None:
+            data = {}
+
+        if self.path:
+            self.client.post(self.path, json=data)

--- a/transip/mixins.py
+++ b/transip/mixins.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 Roald Nefs <info@roaldnefs.com>
+# Copyright (C) 2020, 2021 Roald Nefs <info@roaldnefs.com>
 #
 # This file is part of python-transip.
 
@@ -17,10 +17,17 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Optional, List, Type, Dict, Any
+from typing import Optional, List, Type, Dict, Any, Tuple, Union
 
 from transip import TransIP
 from transip.base import ApiObject
+
+
+# Typing alias for the _create_attrs attribute in the CreateMixin
+CreateAttrsTuple = Tuple[
+    Union[Tuple[()], Tuple[str, ...]],
+    Union[Tuple[()], Tuple[str, ...]]
+]
 
 
 class GetMixin:
@@ -82,13 +89,55 @@ class CreateMixin:
     """
     Create a new ApiObject.
     """
-
     client: TransIP
     path: str
 
-    def create(self, data: Optional[Dict[str, Any]]=None, **kwargs):
+    _req_create_attr: Optional[str] = None
+    _create_attrs: Optional[CreateAttrsTuple] = None
+
+    def _check_create_attrs(self, attrs) -> None:
+        """Check required attributes.
+
+        Raises:
+            AttributeError: If any of the required attributes is missing.
+        """
+        required, optional = self.get_create_attrs()
+        missing = [attr for attr in required if attr not in attrs]
+
+        if missing:
+            attrs_str = "', '".join(missing)
+            raise AttributeError((
+                f"'{self.__class__.__name__}' object has no "
+                f"attribute{'s'[:len(missing)!=1]} '{attrs_str}'"
+            ))
+
+    def get_create_attrs(self) -> Tuple[
+        Union[Tuple[()], Tuple[str, ...]],
+        Union[Tuple[()], Tuple[str, ...]]
+    ]:
+        """Return the required and optional attributes for creating a new
+        object.
+
+        Returns:
+            tuple: a tuple containing a tuple of required and optional
+                attributes.
+        """
+        if not self._create_attrs:
+            return (tuple(), tuple())
+        else:
+            return self._create_attrs
+
+    def create(self, data: Optional[Dict[str, Any]] = None, **kwargs):
         if data is None:
             data = {}
+
+        # Check if all required attributes are supplied
+        self._check_create_attrs(data)
+
+        # Some endpoints require the attributes to be packed in dictionary with
+        # a specific key while others endpoint do not
+        if self._req_create_attr:
+            data = {self._req_create_attr: data}
 
         if self.path:
             self.client.post(self.path, json=data)

--- a/transip/v6/services/domain.py
+++ b/transip/v6/services/domain.py
@@ -20,7 +20,9 @@
 from typing import Optional, Type
 
 from transip.base import ApiService, ApiObject
-from transip.mixins import GetMixin, DeleteMixin, ListMixin
+from transip.mixins import (
+    CreateMixin, GetMixin, DeleteMixin, ListMixin, CreateAttrsTuple
+)
 
 
 class WhoisContact(ApiObject):
@@ -42,13 +44,18 @@ class DnsEntry(ApiObject):
     _id_attr: Optional[str] = None
 
 
-class DnsEntryService(ListMixin, ApiService):
+class DnsEntryService(CreateMixin, ListMixin, ApiService):
     """Service to manage DNS entries of a domain."""
 
     _path: str = "/domains/{parent_id}/dns"
     _obj_cls: Optional[Type[ApiObject]] = DnsEntry
 
     _resp_list_attr: str = "dnsEntries"
+    _req_create_attr: str = "dnsEntry"
+    _create_attrs: Optional[CreateAttrsTuple] = (
+        ("name", "expire", "type", "content"),  # required
+        tuple()  # optional
+    )
 
 
 class Nameserver(ApiObject):
@@ -94,7 +101,7 @@ class Domain(ApiObject):
         )
 
 
-class DomainService(GetMixin, DeleteMixin, ListMixin, ApiService):
+class DomainService(CreateMixin, GetMixin, DeleteMixin, ListMixin, ApiService):
     """Service to manage domain."""
 
     _path: str = "/domains"
@@ -102,3 +109,8 @@ class DomainService(GetMixin, DeleteMixin, ListMixin, ApiService):
 
     _resp_list_attr: str = "domains"
     _resp_get_attr: str = "domain"
+
+    _create_attrs: Optional[CreateAttrsTuple] = (
+        ("domainName",),  # required
+        ("contacts", "nameservers", "dnsEntries")  # optional
+    )

--- a/transip/v6/services/domain.py
+++ b/transip/v6/services/domain.py
@@ -102,7 +102,7 @@ class Domain(ApiObject):
 
 
 class DomainService(CreateMixin, GetMixin, DeleteMixin, ListMixin, ApiService):
-    """Service to manage domain."""
+    """Service to manage domains."""
 
     _path: str = "/domains"
     _obj_cls: Optional[Type[ApiObject]] = Domain

--- a/transip/v6/services/ssh_key.py
+++ b/transip/v6/services/ssh_key.py
@@ -20,7 +20,7 @@
 from typing import Optional, Type
 
 from transip.base import ApiService, ApiObject
-from transip.mixins import GetMixin, DeleteMixin, ListMixin
+from transip.mixins import GetMixin, DeleteMixin, ListMixin, CreateMixin
 
 
 class SshKey(ApiObject):
@@ -28,7 +28,7 @@ class SshKey(ApiObject):
     _id_attr: str = "id"
 
 
-class SshKeyService(GetMixin, DeleteMixin, ListMixin, ApiService):
+class SshKeyService(GetMixin, CreateMixin, DeleteMixin, ListMixin, ApiService):
 
     _path: str = "/ssh-keys"
     _obj_cls: Optional[Type[ApiObject]] = SshKey


### PR DESCRIPTION
Add initial `transip.mixins.CreateMixin` to allow API objects to be created. Even though this should allow all objects to be created, the validation of the required attributes is still missing.

Fixes #15