### PR TITLE
Add option to authenticate using private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@
 ```python
 >>> import transip
 # Initialize a TransIP API client
->>> client = transip.TransIP(access_token="TOKEN")
+>>> client = transip.TransIP(
+...     login="demouser",
+...     private_key_file="/path/to/private.key"
+... )
 # Retrieve a list of VPSs
 >>> for vps in client.vpss.list():
 ...     print(vps)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,10 @@ Release v\ |version|. (:ref:`Installation <install>`)
 
     >>> import transip
     # Initialize a TransIP API client
-    >>> client = transip.TransIP(access_token="TOKEN")
+    >>> client = transip.TransIP(
+    ...     login="demouser",
+    ...     private_key_file="/path/to/private.key"
+    ... )
     # Retrieve a list of VPSs
     >>> for vps in client.vpss.list():
     ...     print(vps)

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -9,6 +9,10 @@ First, make sure that:
 
 * python-transip is :ref:`installed <install>`
 
+Then you should be able to import the module::
+
+    >>> import transip
+
 Below you'll find some simple example to get started.
 
 Authentication
@@ -17,7 +21,20 @@ Authentication
 In order to make requests to the TransIP API we need to authenticate yourself
 using an access token. To get an access token, you should first login to the
 TransIP control panel. You can then generate a new token which will only be
-valid for limited time.
+valid for limited time or generate a private key to allow python-transip to
+request a access token on initialization.
+
+Example of authentication using a private key::
+
+    >>> PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----
+    ... ...
+    ... -----END RSA PRIVATE KEY-----""" 
+    >>> client = transip.TransIP(login="demouser", private_key=PRIVATE_KEY)
+    >>> client = transip.TransIP(login="demouser", private_key_file='/path/to/private.key')
+
+Example authentication using an access token::
+
+    >>> client = transip.TransIP(access_token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImN3MiFSbDU2eDNoUnkjelM4YmdOIn0.eyJpc3MiOiJhcGkudHJhbnNpcC5ubCIsImF1ZCI6ImFwaS50cmFuc2lwLm5sIiwianRpIjoiY3cyIVJsNTZ4M2hSeSN6UzhiZ04iLCJpYXQiOjE1ODIyMDE1NTAsIm5iZiI6MTU4MjIwMTU1MCwiZXhwIjoyMTE4NzQ1NTUwLCJjaWQiOiI2MDQ0OSIsInJvIjpmYWxzZSwiZ2siOmZhbHNlLCJrdiI6dHJ1ZX0.fYBWV4O5WPXxGuWG-vcrFWqmRHBm9yp0PHiYh_oAWxWxCaZX2Rf6WJfc13AxEeZ67-lY0TA2kSaOCp0PggBb_MGj73t4cH8gdwDJzANVxkiPL1Saqiw2NgZ3IHASJnisUWNnZp8HnrhLLe5ficvb1D9WOUOItmFC2ZgfGObNhlL2y-AMNLT4X7oNgrNTGm-mespo0jD_qH9dK5_evSzS3K8o03gu6p19jxfsnIh8TIVRvNdluYC2wo4qDl5EW5BEZ8OSuJ121ncOT1oRpzXB0cVZ9e5_UVAEr9X3f26_Eomg52-PjrgcRJ_jPIUYbrlo06KjjX2h0fzMr21ZE023Gw")
 
 TransIP also provide a **demo token** to authenticate yourself as the TransIP
 demo user in test mode::

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url="https://github.com/roaldnefs/python-transip",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["requests>=2.25.1"],
+    install_requires=["cryptography>=3.3.1", "requests>=2.25.1"],
     python_requires=">=3.6.12",
     entry_points={},
     classifiers=[

--- a/tests/fixtures/auth.json
+++ b/tests/fixtures/auth.json
@@ -1,0 +1,11 @@
+[
+    {
+        "method": "POST",
+        "url": "https://api.transip.nl/v6/auth",
+        "json": {
+            "token": "ACCESS_TOKEN"
+        },
+        "status": 200,
+        "content_type": "application/json"
+    }
+]

--- a/tests/test_transip.py
+++ b/tests/test_transip.py
@@ -18,19 +18,55 @@
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
 import unittest
+import responses  # type: ignore
 
 from transip import TransIP
+from tests.utils import load_responses_fixtures
 
 
 class TransIPTest(unittest.TestCase):
     """Test the TransIP client class."""
 
     client: TransIP
+    privkey: str
 
     @classmethod
-    def setUpClass(self) -> None:
-        """Set up a minimal TransIP client."""
-        self.client = TransIP(access_token='ACCESS_TOKEN')
+    def setUpClass(cls) -> None:
+        """Set up a minimal TransIP client and RSA private key."""
+        cls.client = TransIP(access_token='ACCESS_TOKEN')
+        cls.privkey: str = (  # type: ignore
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIEpAIBAAKCAQEAsUSEHsMuB380OUZQWDyyND4q8lEuJAgNnMkO8s5NGwzP8XSi\n"
+            "2DdFglLGLe9kjpADs3XqZFsk8ZFFn7x0idFydGyh9tbJ2WkR9E+kNUJV5iQDzPOB\n"
+            "wvyygEREqnl/o1h3c1q8tD2HZKBcjChn9JbMzdWwAaIs3ppcGWrEI0jZFFfSAyIZ\n"
+            "GkC3k3umOykWIKflQcT/soAfdqW+2P9/KD/wb3AZCer2i6B2hiITiDbHh5q84Hgk\n"
+            "D/Zg1M4yrYDyxDeGkAJHkGKNaE0tgUPoz3XTGP7uFYIx00qJyhmnzQcyV/Xcw3ZQ\n"
+            "7DFUj1HQ5wG/kEF9a4F1+AAiO5C5QbGTFYSwBwIDAQABAoIBABbtIZlI7P8TOJHf\n"
+            "wixnTTTshWlpjmoikIAikMheXiKNeadkylrkaxz7z53JRFwbzB69tV7dWt3TSAns\n"
+            "ubXJXOAp3JisFtcDe8r5MeeheLKXHda396RcQknMioTxycw6eNh2d8ln28br5oxJ\n"
+            "/YfoqPxGEsljTCJOHHM9F7johwrWSQ6f+gmiOkABvIHKgTBLa++v0D+vNrUjM6rx\n"
+            "IE+dBrx8yIgkF4qSg4Dqnr7D0KqCZUGLZ/3K8ShQUtiQYzyHIWKUId3NUecIQcrT\n"
+            "2Ri2TITKuER0fa7Mr+3LMSh/3+HtP2AoM34ouxr9H98LFz/UXxuFIRFTx7UVRt4N\n"
+            "3zqhsEECgYEA+TnXanBJmFz3sNYtlQixtKrh496GB0NheuK4xeNEj9/3gJ6J/rtL\n"
+            "ZHI7VH8r6aqoqw7sO/WJdxkwZTBOz2fe1QJ5BN0HBI5S6jIBQv9Nfqar0TDvNLB+\n"
+            "pH6eYJZ/IEFIMObv9YmsPohXpGeXynecrpl8SazEIWLb8IzgLY0HpokCgYEAthX5\n"
+            "1th4Re0P9rzXp21bbEwcvOKcg5dcpSaTtA1eQEILl6qqT3FP7w8/Ed7NRRY9Gcs+\n"
+            "inAc96YRNAgIGgfT3R1BmxOMWfdFBT1zlCheS6egKKLzVPzKPiMoMP4zu4hy6uH5\n"
+            "YVqpDLu0YQu1J2L0VYdZ9xAC0//Rx8KRcs6m/g8CgYEA41VDja+HMhf7R67WPU+E\n"
+            "6YvGKRjdoNpxnKoaaUd5TtO46/WxYk5t4t3gCJ9H6wjkecRO8BJ0pdKwNlzuRno0\n"
+            "5JAw26LRt/Iq571dMUO36IMXzuWYDLPBkUJ+LRSaOU3TD+hXkd1W5GNxrmFgMCsT\n"
+            "HKCcooeZD+shPDcEdghipiECgYARBTDbYlSrxKMPX0uRPOmkz+CHz27t5gIk9dws\n"
+            "omtC+ml2/d75mg/surIci4UIhjGj7Zmk+yHaDE3jXTTUqhKlwoxVYJhn+HMdMEdT\n"
+            "fAqEa+DOq5yvPwnwkPy6x6gySWjkh8b10LGonQsZXyzJx7grHoHMVFTPWERVtdw+\n"
+            "rQ5zBQKBgQC0Iwx4eeQYx60OCZpioNEQ3QPaFgqoWYEexmcMlpgQ9ycdnHx3SkE8\n"
+            "SlMokcPIEJDhdF3632kIAHOOJeA4Tmshf+ol/O2U2PDgbJZL6W6FJlT28sZVUU8j\n"
+            "IjFmiAiW6IIEqkJxuR1diAjppEiMmSkjPavo7oQs0TZMMUkli1N9dw==\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+
+    def setUp(self) -> None:
+        """Setup mocked responses for the '/auth' endpoint."""
+        load_responses_fixtures("auth.json")
 
     def test_base_url(self) -> None:
         """Test the base URL of the API."""
@@ -43,3 +79,19 @@ class TransIPTest(unittest.TestCase):
         auth_header: str = self.client.headers["Authorization"]
 
         assert auth_header == "Bearer ACCESS_TOKEN"
+
+    @responses.activate
+    def test_private_key_authorization_header(self) -> None:
+        """
+        Test if TransIP instances initialized with a private key, results in
+        the 'Authorization' header containing the access token returned by the
+        mocked response.
+        """
+        client: TransIP = TransIP(login="testuser", private_key=self.privkey)
+        auth_header: str = self.client.headers["Authorization"]
+
+        # Assert a single request is made to the mocked TransIP API
+        self.assertEqual(len(responses.calls), 1)
+        # Assert the 'Authorization' header contains the access token returned
+        # by the mocked response
+        self.assertEqual(auth_header, "Bearer ACCESS_TOKEN")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Roald Nefs <info@roaldnefs.com>
+#
+# This file is part of python-transip.
+#
+# python-transip is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python-transip is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import string
+
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+from transip.utils import (
+    load_rsa_private_key, generate_message_signature, generate_nonce
+)
+
+
+class UtilsTest(unittest.TestCase):
+    """Test the transip.utils functions."""
+
+    privkey: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.privkey: str = (  # type: ignore
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIEpAIBAAKCAQEAsUSEHsMuB380OUZQWDyyND4q8lEuJAgNnMkO8s5NGwzP8XSi\n"
+            "2DdFglLGLe9kjpADs3XqZFsk8ZFFn7x0idFydGyh9tbJ2WkR9E+kNUJV5iQDzPOB\n"
+            "wvyygEREqnl/o1h3c1q8tD2HZKBcjChn9JbMzdWwAaIs3ppcGWrEI0jZFFfSAyIZ\n"
+            "GkC3k3umOykWIKflQcT/soAfdqW+2P9/KD/wb3AZCer2i6B2hiITiDbHh5q84Hgk\n"
+            "D/Zg1M4yrYDyxDeGkAJHkGKNaE0tgUPoz3XTGP7uFYIx00qJyhmnzQcyV/Xcw3ZQ\n"
+            "7DFUj1HQ5wG/kEF9a4F1+AAiO5C5QbGTFYSwBwIDAQABAoIBABbtIZlI7P8TOJHf\n"
+            "wixnTTTshWlpjmoikIAikMheXiKNeadkylrkaxz7z53JRFwbzB69tV7dWt3TSAns\n"
+            "ubXJXOAp3JisFtcDe8r5MeeheLKXHda396RcQknMioTxycw6eNh2d8ln28br5oxJ\n"
+            "/YfoqPxGEsljTCJOHHM9F7johwrWSQ6f+gmiOkABvIHKgTBLa++v0D+vNrUjM6rx\n"
+            "IE+dBrx8yIgkF4qSg4Dqnr7D0KqCZUGLZ/3K8ShQUtiQYzyHIWKUId3NUecIQcrT\n"
+            "2Ri2TITKuER0fa7Mr+3LMSh/3+HtP2AoM34ouxr9H98LFz/UXxuFIRFTx7UVRt4N\n"
+            "3zqhsEECgYEA+TnXanBJmFz3sNYtlQixtKrh496GB0NheuK4xeNEj9/3gJ6J/rtL\n"
+            "ZHI7VH8r6aqoqw7sO/WJdxkwZTBOz2fe1QJ5BN0HBI5S6jIBQv9Nfqar0TDvNLB+\n"
+            "pH6eYJZ/IEFIMObv9YmsPohXpGeXynecrpl8SazEIWLb8IzgLY0HpokCgYEAthX5\n"
+            "1th4Re0P9rzXp21bbEwcvOKcg5dcpSaTtA1eQEILl6qqT3FP7w8/Ed7NRRY9Gcs+\n"
+            "inAc96YRNAgIGgfT3R1BmxOMWfdFBT1zlCheS6egKKLzVPzKPiMoMP4zu4hy6uH5\n"
+            "YVqpDLu0YQu1J2L0VYdZ9xAC0//Rx8KRcs6m/g8CgYEA41VDja+HMhf7R67WPU+E\n"
+            "6YvGKRjdoNpxnKoaaUd5TtO46/WxYk5t4t3gCJ9H6wjkecRO8BJ0pdKwNlzuRno0\n"
+            "5JAw26LRt/Iq571dMUO36IMXzuWYDLPBkUJ+LRSaOU3TD+hXkd1W5GNxrmFgMCsT\n"
+            "HKCcooeZD+shPDcEdghipiECgYARBTDbYlSrxKMPX0uRPOmkz+CHz27t5gIk9dws\n"
+            "omtC+ml2/d75mg/surIci4UIhjGj7Zmk+yHaDE3jXTTUqhKlwoxVYJhn+HMdMEdT\n"
+            "fAqEa+DOq5yvPwnwkPy6x6gySWjkh8b10LGonQsZXyzJx7grHoHMVFTPWERVtdw+\n"
+            "rQ5zBQKBgQC0Iwx4eeQYx60OCZpioNEQ3QPaFgqoWYEexmcMlpgQ9ycdnHx3SkE8\n"
+            "SlMokcPIEJDhdF3632kIAHOOJeA4Tmshf+ol/O2U2PDgbJZL6W6FJlT28sZVUU8j\n"
+            "IjFmiAiW6IIEqkJxuR1diAjppEiMmSkjPavo7oQs0TZMMUkli1N9dw==\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+
+    def test_load_rsa_private_key(self) -> None:
+        """
+        Test the content of a RSA private key can be converted to a
+        RSAPrivateKey instance.
+        """
+        self.assertTrue(isinstance(load_rsa_private_key(self.privkey), RSAPrivateKey))
+
+    def test_generate_message_signature(self) -> None:
+        """
+        Test message signature generation using the defined RSA private key.
+
+        Example message encoded using:
+        https://8gwifi.org/rsasignverifyfunctions.jsp
+        """
+        message: str = "A message for signing"
+        encoded: str = ("NFi2v07lhYmyTarOtIfpw50W25ukKWjtqsVzti/Y2RiGKPEzJQtFZ"
+                        "QaYJCFfIn8HfYjdbzOTK5DIFxwL8NCJK3Mb+wxZOkO4NDJC7mVgdO"
+                        "I6VuET4F3Er4ZjO4pkMLSaV6B0Mcm/yj8Wom1lfeRZxItDXPAbkMj"
+                        "47Ywsx7enAEXfrZrYwHy+rWLPN6WWCrCDWAJGu7lz5+YIy7rpLyRx"
+                        "Ff57QkMMJal0VCWyQUx+JBMdoW7rGVN1u+AxRY0yFj+QxWRB1z0JC"
+                        "E0Xmur+gQ+4+rgIEDE6VU2VY0A8+SY7hyRb2JN8yoLAeI+21ODwo5"
+                        "h/x1zw3Bstyzuvzo0QmHp7Mw==")
+
+        self.assertTrue(
+            generate_message_signature(message, self.privkey) == encoded
+        )
+
+    def test_generate_nonce_length(self) -> None:
+        """
+        Test the length of the generated nonce and whether or not an
+        exception is thrown for invalid lengths.
+        """
+        # Test valid lengths
+        for length in [1, 2, 32]:
+            self.assertTrue(len(generate_nonce(length)) == length)
+
+        # Test invalid lengths
+        for length in [0, -1]:
+            self.assertRaises(ValueError, generate_nonce, length)
+
+    def test_generate_nonce_alphabet(self) -> None:
+        """
+        Test if the generated nonce only contains characters from the alphabet.
+        """
+        alphabet: str = 'a'
+        self.assertTrue(generate_nonce(3, alphabet) == 'aaa')

--- a/transip/__init__.py
+++ b/transip/__init__.py
@@ -3,27 +3,29 @@
 # Copyright (C) 2020, 2021 Roald Nefs <info@roaldnefs.com>
 #
 # This file is part of python-transip.
-
+#
 # python-transip is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # python-transip is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
-
+#
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 """Wrapper for the TransIP API."""
 
 import importlib
 import requests
+import base64
 
 from typing import Dict, Optional, Any, Type
 
 from transip.exceptions import TransIPHTTPError, TransIPParsingError
+from transip.utils import generate_message_signature, generate_nonce
 
 
 __title__ = "python-transip"
@@ -38,28 +40,40 @@ class TransIP:
     """Represents a TransIP server connection.
 
     Args:
+        login (str): The TransIP username
         api_version (str): TransIP API version to use
         access_token (str): The TransIP API access token
+        private_key (str): The content of the private key for accessing the
+            TransIP API 
+        private_key_file (str): Path to the private key for accessing the
+            TransIP API
     """
 
     def __init__(
         self,
+        login: str = None,
         api_version: str = "6",
-        access_token: Optional[str] = None
+        access_token: Optional[str] = None,
+        private_key: Optional[str] = None,
+        private_key_file: Optional[str] = None,
     ) -> None:
-
         self._api_version: str = api_version
         self._url: str = f"https://api.transip.nl/v{api_version}"
-        self._access_token: Optional[str] = access_token
 
         # Headers to use when making a request to TransIP
         self.headers: Dict[str, str] = {
-            "User-Agent": f"{__title__}/{__version__}",
-            "Authorization": f"Bearer {access_token}"
+            "User-Agent": f"{__title__}/{__version__}"
         }
 
         # Initialize a session object for making requests
         self.session: requests.Session = requests.Session()
+
+        # Set authentication information
+        self._login: str = login
+        self._access_token: Optional[str] = access_token
+        self._private_key: Optional[str] = private_key
+        self._private_key_file: Optional[str] = private_key_file
+        self._set_auth_info()
 
         # Dynamically import the services for the specified API version
         objects = importlib.import_module(f"transip.v{api_version}.objects")
@@ -91,62 +105,124 @@ class TransIP:
     def _build_url(self, path: str) -> str:
         return f"{self._url}{path}"
 
-    def _send(
-        self,
-        method: str,
-        path: str,
-        data: Optional[Any] = None,
-        json: Optional[Any] = None,
-        params: Optional[Dict[str, Any]] = None
-    ) -> requests.Response:
-        """Make an HTTP request to the TransIP API.
-
-        Args:
-            method (str): HTTP method to use
-            path (str): The path to append to the API URL
-            data (dict): The body to attach to the request
-            json (dict): The json body to attach to the request
-            params (dict): URL parameters to append to the URL
+    def _request_access_token(self) -> str:
+        """
+        Request an access token using the supplied private key.
 
         Returns:
-            A requests response object.
+            str: The access token to use for authorization.
 
         Raises:
-            TransIPHTTPError: When the return code of the request is not 2xx
+            TransIPParsingError: If the requested access token couldn't be
+                extracted from the API response.
         """
-        url: str = self._build_url(path)
 
-        # Set the content type for the request if json is provided and data is
-        # not specified
-        content_type: Optional[str] = None
-        if not data and json:
-            content_type = "application/json"
+        url: str = self._build_url('/auth')
+        payload: Dict[str, Any] = {
+            "login": self._login,
+            # The TransIP API requires that the length of the nonce is between
+            # 6 and 32 characters
+            "nonce": generate_nonce(32),
+            # TODO(roaldnefs): Allow the creation of read-only access tokens
+            "read_only": False,
+            # TODO(roaldnefs): Allow the expiration time of the access token
+            # to be overwritten
+            # "expiration_time": "30 minutes",
+            # TODO(roaldnefs): Allow a custom label to be specified when
+            # generating a new access token
+            # "label": "python-transip",
+            # TODO(roaldnefs): Allow the access token to only be use from
+            # whitelisted IP-addresses
+            "global_key": False
+        }
 
-        headers: Dict[str, str] = self._get_headers(content_type)
-        request: requests.Request = requests.Request(
-            method, url, headers=headers, data=data, json=json, params=params,
-        )
+        headers: Dict[str, str] = self.headers.copy()
+        request: requests.Request = requests.Request("POST", url, headers=headers, json=payload)
+        prepped: requests.PreparedRequest = self.session.prepare_request(request)
 
-        prepped: requests.PreparedRequest = self.session.prepare_request(
-            request
-        )
+        # Get the prepped body for signature generation
+        body: str = prepped.body
+
+        # Generate a signature if the request body
+        signature: str = generate_message_signature(body, self._private_key)
+
+        # Add 'Signature' header to the prepared request
+        prepped.headers["Signature"] = signature
+
         response: requests.Response = self.session.send(prepped)
+        data = self._validate_response(response)
 
-        if 200 <= response.status_code < 300:
-            return response
-
-        error_message = str(response.content)
+        # Attempt to extract the access token from the result
         try:
-            error_json = response.json()
-            if "error" in error_json:
-                error_message = error_json["error"]
-        except (KeyError, ValueError, TypeError):
-            pass
+            return data['token']
+        except (AttributeError, KeyError) as exc:
+            raise TransIPParsingError(
+                "Failed to extract access token from the API response"
+            ) from exc
 
-        raise TransIPHTTPError(
-            message=error_message,
-            response_code=response.status_code
-        )
+    def _read_private_key(self) -> str:
+        """Read the private key from file.
+
+        Returns:
+            str: The private key content
+        
+        Raises:
+            RuntimeError: If the private key file doesn't exist
+        """
+        if os.path.exists(self._private_key_file):
+            try:
+                with open(self._private_key_file) as keyfile:
+                    return keyfile.read()
+            except IOError as exc:
+                raise RuntimeError("The private key couldn't be read") from exc
+        else:
+            raise RuntimeError("The private key doesn't exist")
+
+    def _set_auth_info(self) -> None:
+        """
+        Set authentication information based upon the defined attributes.
+        
+        Raises:
+            ValueError: If the required attributes are not defined.
+        """
+        if not self._access_token and not self._private_key and not self._private_key_file:
+            raise ValueError(
+                "At least one of access_token, private_key and "
+                "private_key_file should be defined"
+            )
+        if self._access_token and self._private_key:
+            raise ValueError(
+                "Only one of access_token and private_key should be defined"
+            )
+        if self._access_token and self._private_key_file:
+            raise ValueError(
+                "Only one of access_token and private_key_file should be "
+                "defined"
+            )
+        if self._private_key and self._private_key_file:
+            raise ValueError(
+                "Only one of private_key and private_key_file should be "
+                "defined"
+            )
+        if self._private_key and not self._login:
+            raise ValueError(
+                "Both private_key and login should be defined"
+            )
+        if self._private_key_file and not self._login:
+            raise ValueError(
+                "Both private_key_file and login should be defined"
+            )
+
+        # Read the private key from file
+        if self._private_key_file:
+            self._private_key = self._read_private_key()
+
+        # Use the private key to request a new access token
+        if self._private_key:
+            self._access_token = self._request_access_token()
+
+        # Set the 'Authorization' header
+        self.headers["Authorization"] = f"Bearer {self._access_token}"
 
     def request(
         self,
@@ -170,19 +246,57 @@ class TransIP:
 
         Raises:
             TransIPHTTPError: When the return code of the request is not 2xx
+            TransIPParsingError: When the content couldn't be parsed as JSON
         """
-        response: requests.Response = self._send(
-            method, path, data=data, json=json, params=params
+        url: str = self._build_url(path)
+
+        # Set the content type for the request if json is provided and data is
+        # not specified
+        content_type: Optional[str] = None
+        if not data and json:
+            content_type = "application/json"
+
+        headers: Dict[str, str] = self._get_headers(content_type)
+        request: requests.Request = requests.Request(
+            method, url, headers=headers, data=data, json=json, params=params,
         )
 
-        if response.text:
-            try:
-                return response.json()
-            except Exception:
-                raise TransIPParsingError(
-                    message="Failed to parse the API response as JSON"
-                )
-        return None
+        prepped: requests.PreparedRequest = self.session.prepare_request(
+            request
+        )
+        response: requests.Response = self.session.send(prepped)
+        return self._validate_response(response)
+
+    def _validate_response(self, response: requests.Response) -> Any:
+        """
+        Validate the API response.
+        
+        Raises:
+            TransIPHTTPError: When the return code of the request is not 2xx
+            TransIPParsingError: When the content couldn't be parsed as JSON
+        """
+        if 200 <= response.status_code < 300:
+            if response.text:
+                try:
+                    return response.json()
+                except Exception:
+                    raise TransIPParsingError(
+                        message="Failed to parse the API response as JSON"
+                    )
+            return None
+
+        error_message = str(response.content)
+        try:
+            error_json = response.json()
+            if "error" in error_json:
+                error_message = error_json["error"]
+        except (KeyError, ValueError, TypeError):
+            pass
+
+        raise TransIPHTTPError(
+            message=error_message,
+            response_code=response.status_code
+        )
 
     def get(
         self,

--- a/transip/utils.py
+++ b/transip/utils.py
@@ -75,15 +75,22 @@ def generate_message_signature(
     return b64_bytes.decode('ascii')
 
 
-def generate_nonce(length: int) -> str:
+def generate_nonce(length: int, alphabet: str = None) -> str:
     """
     Generate a nonce.
 
     Args:
         length (int): The number of characters to return.
+        alphabet (str): The alphabet to choose characters from, defaults to
+            ascii leters and digits.
 
     Returns:
         str: The nonce of specified characters.
     """
-    alphabet: str = string.ascii_letters + string.digits
+    if not length >= 1:
+        raise ValueError(
+            "The specified nonce length must greater or equal to 1"
+        )
+
+    alphabet = alphabet or (string.ascii_letters + string.digits)
     return ''.join(secrets.choice(alphabet) for i in range(length))

--- a/transip/utils.py
+++ b/transip/utils.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Roald Nefs <info@roaldnefs.com>
+#
+# This file is part of python-transip.
+#
+# python-transip is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python-transip is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
+
+import base64
+import os
+import secrets
+import string
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.hashes import SHA512
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+
+
+def load_rsa_private_key(key: str) -> RSAPrivateKey:
+    """
+    Convert the private key string to RSAPrivateKey object.
+    
+    Returns:
+        RSAPrivateKey: The private RSA key.
+    """
+    # Convert the key string to bytes
+    if isinstance(key, str):
+        key: bytes = key.encode()
+    
+    return serialization.load_pem_private_key(
+        key, password=None, backend=default_backend()
+    )
+
+
+def generate_message_signature(message: str, private_key: str) -> str:
+    """Return the BASE64 encoded SHA514 signature of a message.
+    
+    Args:
+        message (str): The message to sign.
+        private_key (str): The private key content used to sign the message.
+    
+    Returns:
+        str: The BASE64 encoded SHA514 signature of a message.
+    """
+    # Convert the message string to bytes
+    if isinstance(message, str):
+        message: bytes = message.encode()
+
+    # Convert the private key content to a RSAPrivateKey object
+    if isinstance(private_key, str):
+        private_key: RSAPrivateKey = load_rsa_private_key(private_key)
+
+    # Sign the message using the RSAPrivateKey object
+    signature: str = private_key.sign(message, PKCS1v15(), SHA512())
+
+    # Return the BASE64 encoded SHA512 signature
+    return base64.b64encode(signature)
+
+
+def generate_nonce(length: int) -> str:
+    """
+    Generate a nonce.
+
+    Args:
+        length (int): The number of characters to return.
+
+    Returns:
+        str: The nonce of specified characters.
+    """
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for i in range(length))


### PR DESCRIPTION
The TransIP API also allows the creation of an access token by using a private key. By allowing the user to specify either an access token or private key when initialising a new `transip.TransIP` client, the client could dynamically generate a new access token when a private key is used.

Fixes #14