### PR TITLE
feat: add update mixin for API objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@ All notable changes in **python-transip** are documented below.
 - This `CHANGELOG.md` file to be able to list all notable changes for each version of **python-transip**.
 - The `transip.v6.objects.ApiTestService` service to allow calling the test resource to make sure everything is working.
 - The `transip.v6.objects.InvoiceItemService` service to allow listing all invoice items on a `transip.v6.objects.Invoice` object.
+- The `transip.mixins.ObjectUpdateMixin` mixin to allow calling `update()` on API object directly.
 
 [Unreleased]: https://github.com/roaldnefs/python-transip/compare/v0.3.0...HEAD

--- a/tests/services/test_ssh_keys.py
+++ b/tests/services/test_ssh_keys.py
@@ -65,13 +65,22 @@ class SshKeysTest(unittest.TestCase):
 
     @responses.activate
     def test_delete_object(self) -> None:
-        ssh_key_id: int = 123
-        ssh_key: SshKey = self.client.ssh_keys.get(ssh_key_id)  # type: ignore
+        ssh_key: SshKey = self.client.ssh_keys.get(123)  # type: ignore
 
         try:
             ssh_key.delete()  # type: ignore
         except Exception as exc:
             assert False, f"'transip.v6.objects.SshKey.delete' raised an exception {exc}"
+
+    @responses.activate
+    def test_update_object(self) -> None:
+        ssh_key: SshKey = self.client.ssh_keys.get(123)  # type: ignore
+        ssh_key.description = "Jim key"
+
+        try:
+            ssh_key.update()
+        except Exception as exc:
+            assert False, f"'transip.v6.objects.SshKey.update' raised an exception {exc}"
 
     @responses.activate
     def test_create(self) -> None:

--- a/transip/base.py
+++ b/transip/base.py
@@ -32,17 +32,21 @@ class ApiObject:
             {
                 "service": service,
                 "_attrs": attrs,
+                "_updated_attrs": {}
             }
         )
 
     def __getattr__(self, name: str) -> Any:
         try:
-            return self.__dict__["_attrs"][name]
+            return self.__dict__["_updated_attrs"][name]
         except KeyError:
-            raise AttributeError(name)
+            try:
+                return self.__dict__["_attrs"][name]
+            except KeyError:
+                raise AttributeError(name)
 
     def __setattr__(self, name: str, value: Any) -> None:
-        self.__dict__["_attrs"][name] = value
+        self.__dict__["_updated_attrs"][name] = value
 
     def __str__(self) -> str:
         return f"{type(self)} => {self._attrs}"
@@ -65,7 +69,12 @@ class ApiObject:
 
     @property
     def attrs(self):
-        return self.__dict__["_attrs"]
+        """
+        Returns a dictionary containing all the attributes.
+        """
+        attrs = self.__dict__["_updated_attrs"].copy()
+        attrs.update(self.__dict__["_attrs"])
+        return attrs
 
 
 class ApiService:

--- a/transip/mixins.py
+++ b/transip/mixins.py
@@ -77,6 +77,33 @@ class ObjectDeleteMixin:
             self.service.delete(self.get_id())  # type: ignore
 
 
+class ObjectUpdateMixin:
+    """Update a single ApiObject."""
+
+    service: ApiService
+    _updated_attrs: Any
+
+    def _get_updated_data(self) -> Union[Dict, Dict[str, Any]]:
+        updated_data = {}
+        required, optional = self.service.get_update_attrs()  # type: ignore
+        # Add all required attributes, even if they haven't been updated
+        for attr in required:
+            updated_data[attr] = getattr(self, attr)
+        updated_data.update(self._updated_attrs)
+        return updated_data
+
+    def update(self) -> None:
+        """
+        Update the changes made to the object.
+        """
+        updated_data = self._get_updated_data()
+        if not updated_data:
+            return
+
+        obj_id = self.get_id()  # type: ignore
+        self.service.update(obj_id, updated_data)  # type: ignore
+
+
 class ListMixin:
     """
     Retrieve a list of ApiObjects.

--- a/transip/v6/objects.py
+++ b/transip/v6/objects.py
@@ -22,7 +22,7 @@ from typing import Optional, Type
 from transip.base import ApiService, ApiObject
 from transip.mixins import (
     GetMixin, DeleteMixin, ListMixin, CreateMixin, UpdateMixin,
-    ObjectDeleteMixin,
+    ObjectDeleteMixin, ObjectUpdateMixin,
     CreateAttrsTuple, UpdateAttrsTuple
 )
 
@@ -57,7 +57,7 @@ class AvailabilityZoneService(ListMixin, ApiService):
     _resp_list_attr: str = "availabilityZones"
 
 
-class SshKey(ObjectDeleteMixin, ApiObject):
+class SshKey(ObjectDeleteMixin, ObjectUpdateMixin, ApiObject):
 
     _id_attr: str = "id"
 


### PR DESCRIPTION
Add `transip.mixins.ObjectUpdateMixin` for calling `update()` on API objects directly to update instances.
