### PR TITLE
feat: allow invoice to be written to PDF file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@ All notable changes in **python-transip** are documented below.
 - The `transip.v6.objects.ApiTestService` service to allow calling the test resource to make sure everything is working.
 - The `transip.v6.objects.InvoiceItemService` service to allow listing all invoice items on a `transip.v6.objects.Invoice` object.
 - The `transip.mixins.ObjectUpdateMixin` mixin to allow calling `update()` on API object directly.
+- Allow an invoice to be written to a PDF file by calling the `pdf()` method on a `transip.v6.objects.Invoice` object.
 
 [Unreleased]: https://github.com/roaldnefs/python-transip/compare/v0.3.0...HEAD

--- a/transip/exceptions.py
+++ b/transip/exceptions.py
@@ -50,3 +50,7 @@ class TransIPHTTPError(TransIPError):
 
 class TransIPParsingError(TransIPError):
     pass
+
+
+class TransIPIOError(TransIPError):
+    pass


### PR DESCRIPTION
Allow an invoice to be written to a PDF file by calling the `pdf()` method on a `transip.v6.objects.Invoice` object.