### PR TITLE
feat: add service to list products and elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,6 @@ All notable changes in **python-transip** are documented below.
 - The `transip.v6.objects.InvoiceItemService` service to allow listing all invoice items on a `transip.v6.objects.Invoice` object.
 - The `transip.mixins.ObjectUpdateMixin` mixin to allow calling `update()` on API object directly.
 - Allow an invoice to be written to a PDF file by calling the `pdf()` method on a `transip.v6.objects.Invoice` object.
+- The `transip.v6.objects.ProductService` service to allow listing all products as a `transip.v6.objects.Product` object.
 
 [Unreleased]: https://github.com/roaldnefs/python-transip/compare/v0.3.0...HEAD

--- a/tests/fixtures/general.json
+++ b/tests/fixtures/general.json
@@ -13,7 +13,7 @@
             "products": {
                 "vps": [
                     {
-                        "name": "example-product-name",
+                        "name": "vps-bladevps-x4",
                         "description": "This is an example product",
                         "price": 499,
                         "recurringPrice": 799
@@ -58,7 +58,7 @@
     },
     {
         "method": "GET",
-        "url": "https://api.transip.nl/v6/products/ipv4Addresses/elements",
+        "url": "https://api.transip.nl/v6/products/vps-bladevps-x4/elements",
         "json": {
             "productElements": [
                 {

--- a/tests/services/test_products.py
+++ b/tests/services/test_products.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 Roald Nefs <info@roaldnefs.com>
+#
+# This file is part of python-transip.
+#
+# python-transip is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python-transip is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import List, Tuple, Any, Dict, Optional
+import responses  # type: ignore
+import unittest
+import tempfile
+import os
+
+from transip import TransIP
+from transip.v6.objects import Product, ProductElement
+from tests.utils import load_responses_fixtures
+
+
+class ProductsTest(unittest.TestCase):
+    """Test the ProductsService."""
+
+    client: TransIP
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up a minimal TransIP client for using the invoice services."""
+        cls.client = TransIP(access_token='ACCESS_TOKEN')
+
+    def setUp(self) -> None:
+        """Setup mocked responses for the '/products' endpoint."""
+        load_responses_fixtures("general.json")
+
+    @responses.activate
+    def test_list(self) -> None:
+        """Check if the products can be listed."""
+        products: List[Product] = self.client.products.list()  # type: ignore
+    
+        self.assertEqual(len(products), 5)
+
+    @responses.activate
+    def test_elements_list(self) -> None:
+        """Check if the elements of a product can be listed."""
+        products: List[Product] = self.client.products.list()  # type: ignore
+        product: Optional[Product] = None
+
+        # Find the correct product as the API doesn't provide an option to
+        # retrieve a single product
+        for entry in products:
+            if entry.get_id() == 'vps-bladevps-x4':
+                product = entry
+                break
+        
+        self.assertIsNotNone(product)
+
+        elements = product.elements.list()  # type: ignore
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0].get_id(), 'ipv4Addresses')  # type: ignore

--- a/transip/__init__.py
+++ b/transip/__init__.py
@@ -93,6 +93,9 @@ class TransIP:
         self.availability_zones: Type['ApiService'] = (
             objects.AvailabilityZoneService(self)  # type: ignore
         )
+        self.products: Type['ApiService'] = (
+            objects.ProductService(self)  # type: ignore
+        )
         self.domains: Type['ApiService'] = (
             objects.DomainService(self)  # type: ignore
         )

--- a/transip/base.py
+++ b/transip/base.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 Roald Nefs <info@roaldnefs.com>
+# Copyright (C) 2020, 2021 Roald Nefs <info@roaldnefs.com>
 #
 # This file is part of python-transip.
 #
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-transip.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Optional, Type, Any
+from typing import Optional, Type, Any, Union
 
 from transip import TransIP
 
@@ -61,8 +61,8 @@ class ApiObject:
     def __dir__(self):
         return super().__dir__() + list(self.attrs)
 
-    def get_id(self) -> Any:
-        """Returns the id of the object."""
+    def get_id(self) -> Union[Optional[int], Optional[str]]:
+        """Returns the ID of the object."""
         if self._id_attr and hasattr(self, self._id_attr):
             return getattr(self, self._id_attr)
         return None


### PR DESCRIPTION
Add services to list products and product elements:
- The `transip.v6.objects.ProductService` service to allow listing all products as a `transip.v6.objects.Product` object.
- The `transip.v6.objects.ProductElementService` service to allow listing all elements of a `transip.v6.objects.Product` objects as `transip.v6.objects.ProductElement` instances.

Fixes #23
