### PR TITLE
feat: allow DNS record(s) to be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes in **python-transip** are documented below.
 ## [Unreleased]
 ### Added
 - This `CHANGELOG.md` file to be able to list all notable changes for each version of **python-transip**.
-- The `transip.v6.objects.ApiTestService` service to allow calling the test resource to make sure everything is working.
-- The `transip.v6.objects.InvoiceItemService` service to allow listing all invoice items on a `transip.v6.objects.Invoice` object.
-- The `transip.mixins.ObjectUpdateMixin` mixin to allow calling `update()` on API object directly.
-- Allow an invoice to be written to a PDF file by calling the `pdf()` method on a `transip.v6.objects.Invoice` object.
-- The `transip.v6.objects.ProductService` service to allow listing all products as a `transip.v6.objects.Product` object.
+- The `transip.TransIP.api_test` service to allow calling the test resource to make sure everything is working.
+- The option to list all invoices attached to your TransIP account from the `transip.TransIP.invoices` service.
+- The option to save an invoice as PDF file from `transip.v6.objects.Invoice` object.
+- The option to list all products available in TransIP from the `transip.TransIP.products` service.
+- The option to update a single SSH key from `transip.v6.objects.SshKey` object.
+- The option to update the content of a single DNS record from the `transip.v6.objects.Domain.dns` service, as well as from the `transip.v6.objects.DnsEntry` object.
 
 [Unreleased]: https://github.com/roaldnefs/python-transip/compare/v0.3.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ All notable changes in **python-transip** are documented below.
 - The option to list all products available in TransIP from the `transip.TransIP.products` service.
 - The option to update a single SSH key from `transip.v6.objects.SshKey` object.
 - The option to update the content of a single DNS record from the `transip.v6.objects.Domain.dns` service, as well as from the `transip.v6.objects.DnsEntry` object.
+- The option to replace all existing DNS records of a single domain at once from the `transip.v6.objects.Domain.dns` service.
 
 [Unreleased]: https://github.com/roaldnefs/python-transip/compare/v0.3.0...HEAD

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
         - [The **DnsEntry** class](#the-dnsentry-class)
         - [List all DNS entries for a domain](#list-all-dns-entries-for-a-domain)
         - [Add a new single DNS entry to a domain](#add-a-new-single-dns-entry-to-a-domain)
+        - [Update single DNS entry](#update-single-dns-entry)
         - [Remove a DNS entry from a domain](#remove-a-dns-entry-from-a-domain)
 - [VPS](#vps)
 - [HA-IP](#ha-ip)
@@ -524,6 +525,7 @@ The **DnsEntry** class makes the following attributes available:
 The class has the following methods:
 
 - **delete()** will delete the DNS-record from the domain.
+- **update()** will send the updated attributes to the TransIP API. This can only be used when updating the **content** attribute of a DnsEntry and when there aren't any other DNS records with the same **name**, **expire** and **type** attributes.
 
 #### List all DNS entries for a domain
 Retrieve the DNS records of a single domain registered in your TransIP account by calling **dns.list()** on a **transip.v6.objects.Domain** object. This will return a list of **transip.v6.objects.DnsEntry** objects.
@@ -563,6 +565,30 @@ dns_entry_data = {
 }
 # Add the DNS record to the domain.
 domain.delete(dns_entry_data)
+```
+
+#### Update single DNS entry
+Update a single DNS record of a domain by calling **dns.update(_data_)** on a **transip.v6.objects.Domain** object. The **data** keyword argument a dictionary containing the **name**, **expire**, **type** and **content** attributes.
+
+This can only be used when updating the **content** attribute of a DNS entry and when there aren't any other DNS records with the same **name**, **expire** and **type** attributes.
+
+For example:
+```python
+import transip
+# Initialize a client using the TransIP demo token.
+client = transip.TransIP(access_token=transip.v6.DEMO_TOKEN)
+
+# Retrieve a domain by its name.
+domain = client.domains.get('transipdemonstratie.nl')
+# Dictionary containing the information for a single updated DNS record.
+dns_entry_data = {
+    "name": "www",
+    "expire": 86400,
+    "type": "A",
+    "content": "127.0.0.2"  # The update content.
+}
+# Update the content of a single DNS record.
+domain.update(dns_entry_data)
 ```
 
 #### Remove a DNS entry from a domain

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
         - [List all DNS entries for a domain](#list-all-dns-entries-for-a-domain)
         - [Add a new single DNS entry to a domain](#add-a-new-single-dns-entry-to-a-domain)
         - [Update single DNS entry](#update-single-dns-entry)
+        - [Update all DNS entries for a domain](#update-all-dns-entries-for-a-domain)
         - [Remove a DNS entry from a domain](#remove-a-dns-entry-from-a-domain)
 - [VPS](#vps)
 - [HA-IP](#ha-ip)
@@ -589,6 +590,31 @@ dns_entry_data = {
 }
 # Update the content of a single DNS record.
 domain.update(dns_entry_data)
+```
+
+#### Update all DNS entries for a domain
+Update all DNS records of a single domain registered in your TransIP account at once by calling **dns.replace()** on a **transip.v6.objects.Domain** object.
+
+**Note:** This will wipe all existing DNS records with the provided records.
+
+For example:
+```python
+import transip
+# Initialize a client using the TransIP demo token.
+client = transip.TransIP(access_token=transip.v6.DEMO_TOKEN)
+
+# Retrieve a domain by its name.
+domain = client.domains.get('transipdemonstratie.nl')
+# Retrieve the DNS records of a single domain.
+records = domain.dns.list()
+
+for record in records:
+    # Update the A-record for localhost
+    if record.name == 'localhost' and record.type == 'A':
+        record.content = '127.0.0.1'
+
+# Replace all the records with the updated ones
+domain.dns.replace(records)
 ```
 
 #### Remove a DNS entry from a domain

--- a/tests/fixtures/domains.json
+++ b/tests/fixtures/domains.json
@@ -295,6 +295,22 @@
         }
     },
     {
+        "method": "PUT",
+        "url": "https://api.transip.nl/v6/domains/example.com/dns",
+        "status": 204,
+        "content_type": "application/json",
+        "match_json_params": {
+            "dnsEntries": [
+                {
+                    "name": "www",
+                    "expire": 86400,
+                    "type": "A",
+                    "content": "127.0.0.2"
+                }
+            ]
+        }
+    },
+    {
         "method": "PATCH",
         "url": "https://api.transip.nl/v6/domains/example.com/dns",
         "status": 204,

--- a/tests/fixtures/domains.json
+++ b/tests/fixtures/domains.json
@@ -295,6 +295,20 @@
         }
     },
     {
+        "method": "PATCH",
+        "url": "https://api.transip.nl/v6/domains/example.com/dns",
+        "status": 204,
+        "content_type": "application/json",
+        "match_json_params": {
+            "dnsEntry": {
+                  "name": "www",
+                  "expire": 86400,
+                  "type": "A",
+                  "content": "127.0.0.2"
+            }
+        }
+    },
+    {
         "method": "GET",
         "url": "https://api.transip.nl/v6/domains/example.com/nameservers",
         "json": {

--- a/tests/services/test_domains.py
+++ b/tests/services/test_domains.py
@@ -78,6 +78,28 @@ class DomainsTest(unittest.TestCase):
         self.assertEqual(entry.content, "127.0.0.1")  # type: ignore
 
     @responses.activate
+    def test_dns_replace(self) -> None:
+        """
+        Check if the existing DNS records for a single domain can be replaced
+        at once.
+        """
+        domain: Domain = self.client.domains.get("example.com")  # type: ignore
+        records: List[DnsEntry] = domain.dns.list()  # type: ignore
+
+        # Ensure we have a single DNS record
+        self.assertEqual(len(records), 1)
+        # Update the content of the first DNS record in the list of existing
+        # records.
+        records[0].content = '127.0.0.2'
+
+        # Replace all existing records.
+        try:
+            domain.dns.replace(records)  # type: ignore
+        except Exception as exc:
+            assert False, f"'transip.v6.objects.Domain.dns.replace' raised an exception {exc}"
+
+
+    @responses.activate
     def test_dns_create(self) -> None:
         dns_entry_data: Dict[str, Union[str, int]] = {
             "name": "www",

--- a/transip/mixins.py
+++ b/transip/mixins.py
@@ -23,13 +23,12 @@ from transip import TransIP
 from transip.base import ApiObject, ApiService
 
 
-# Typing alias for the _create_attrs attribute in the CreateMixin
-CreateAttrsTuple = Tuple[
+# Typing alias for the _create_attrs, _update_attrs and _delete_attrs
+# attributes in the CreateMixin, UpdateMixin and DeleteMixin
+AttrsTuple = Tuple[
     Union[Tuple[()], Tuple[str, ...]],
     Union[Tuple[()], Tuple[str, ...]]
 ]
-# Typing alias for the _update_attrs attribute in the UpdateMixin
-UpdateAttrsTuple = CreateAttrsTuple
 
 
 class GetMixin:
@@ -134,7 +133,7 @@ class UpdateMixin:
     path: str
 
     _req_update_attr: Optional[str] = None
-    _update_attrs: Optional[CreateAttrsTuple] = None
+    _update_attrs: Optional[AttrsTuple] = None
 
     def get_update_attrs(self) -> Tuple[
         Union[Tuple[()], Tuple[str, ...]],
@@ -198,7 +197,7 @@ class CreateMixin:
     path: str
 
     _req_create_attr: Optional[str] = None
-    _create_attrs: Optional[CreateAttrsTuple] = None
+    _create_attrs: Optional[AttrsTuple] = None
 
     def _check_create_attrs(self, attrs) -> None:
         """

--- a/transip/v6/objects.py
+++ b/transip/v6/objects.py
@@ -24,7 +24,7 @@ from typing import Optional, Type, List, Dict, Any
 
 from transip.base import ApiService, ApiObject
 from transip.mixins import (
-    GetMixin, DeleteMixin, ListMixin, CreateMixin, UpdateMixin,
+    GetMixin, DeleteMixin, ListMixin, CreateMixin, UpdateMixin, ReplaceMixin,
     ObjectDeleteMixin, ObjectUpdateMixin,
     AttrsTuple
 )
@@ -181,7 +181,7 @@ class DnsEntry(ObjectUpdateMixin, ApiObject):
         self.service.update(updated_data)  # type: ignore
 
 
-class DnsEntryService(CreateMixin, ListMixin, ApiService):
+class DnsEntryService(CreateMixin, ListMixin, ReplaceMixin, ApiService):
     """Service to manage DNS entries of a domain."""
 
     _path: str = "/domains/{parent_id}/dns"
@@ -209,6 +209,14 @@ class DnsEntryService(CreateMixin, ListMixin, ApiService):
     # can't be used as DNS entries don't have an ID.
     _req_delete_attr: str = "dnsEntry"
     _delete_attrs: AttrsTuple = (
+        ("name", "expire", "type", "content"),  # required
+        tuple()  # optional
+    )
+
+    # Additional data from replacing all existing DnsEntry objects using the
+    # ReplaceMixin.
+    _req_replace_attr: str = "dnsEntries"
+    _replace_attrs: AttrsTuple = (
         ("name", "expire", "type", "content"),  # required
         tuple()  # optional
     )


### PR DESCRIPTION
Allow DNS record(s) to be updated:

- Allow a single DNS record to be updated. This will only allow the content of the DNS record to be updated when no other DNS records with the same name, expiry time and type exists.
- Allow all DNS records to be replaced at once.

Fixes #36 