### PR TITLE
fix: add argument to disable IP whitelisting (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes in **python-transip** are documented below.
 - The option to replace all existing nameservers of a single domain at once from the `transip.v6.objects.Domain.nameservers` service.
 - The option to list all colocations from the `transip.TransIP.colocations` service ([#24](https://github.com/roaldnefs/python-transip/issues/24)).
 - The option to retrieve a single colocation by name from the `transip.TransIP.colocations` service ([#24](https://github.com/roaldnefs/python-transip/issues/24)).
+- The option to allow the access token to be used from all IP-addresses instead of only the whitelisted ones ([#46](https://github.com/roaldnefs/python-transip/issues/46)).
 
 ## [0.4.0] (2021-01-24)
 ### Added

--- a/transip/__init__.py
+++ b/transip/__init__.py
@@ -54,6 +54,7 @@ class TransIP:
             TransIP API
         private_key_file (str): Path to the private key for accessing the
             TransIP API
+        global_key (bool): Enable/disable IP whitelisting
     """
 
     def __init__(
@@ -63,6 +64,7 @@ class TransIP:
         access_token: Optional[str] = None,
         private_key: Optional[str] = None,
         private_key_file: Optional[str] = None,
+        global_key: Optional[bool] = False,
     ) -> None:
         self._api_version: str = api_version
         self._url: str = f"https://api.transip.nl/v{api_version}"
@@ -80,6 +82,7 @@ class TransIP:
         self._access_token: Optional[str] = access_token
         self._private_key: Optional[str] = private_key
         self._private_key_file: Optional[str] = private_key_file
+        self._global_key: Optional[bool] = global_key
         self._set_auth_info()
 
         # Dynamically import the services for the specified API version
@@ -156,7 +159,7 @@ class TransIP:
             # "label": "python-transip",
             # TODO(roaldnefs): Allow the access token to only be use from
             # whitelisted IP-addresses
-            "global_key": False
+            "global_key": self._global_key
         }
 
         headers: Dict[str, str] = self.headers.copy()

--- a/transip/__init__.py
+++ b/transip/__init__.py
@@ -54,7 +54,8 @@ class TransIP:
             TransIP API
         private_key_file (str): Path to the private key for accessing the
             TransIP API
-        global_key (bool): Enable/disable IP whitelisting
+        global_key (bool): Allow the access token to be used from all
+            IP-addresses instead of only the whitelisted ones.
     """
 
     def __init__(
@@ -64,7 +65,7 @@ class TransIP:
         access_token: Optional[str] = None,
         private_key: Optional[str] = None,
         private_key_file: Optional[str] = None,
-        global_key: Optional[bool] = False,
+        global_key: bool = False,
     ) -> None:
         self._api_version: str = api_version
         self._url: str = f"https://api.transip.nl/v{api_version}"
@@ -157,8 +158,6 @@ class TransIP:
             # TODO(roaldnefs): Allow a custom label to be specified when
             # generating a new access token
             # "label": "python-transip",
-            # TODO(roaldnefs): Allow the access token to only be use from
-            # whitelisted IP-addresses
             "global_key": self._global_key
         }
 

--- a/transip/utils.py
+++ b/transip/utils.py
@@ -41,9 +41,15 @@ def load_rsa_private_key(key: Union[bytes, str]) -> RSAPrivateKey:
     if isinstance(key, str):
         key = key.encode()
 
-    return serialization.load_pem_private_key(
+    private_key = serialization.load_pem_private_key(
         key, password=None, backend=default_backend()
     )
+
+    # Check type of the loaded private key
+    if not isinstance(private_key, RSAPrivateKey):
+        raise ValueError('The supplied key must be a RSA private key')
+
+    return private_key
 
 
 def generate_message_signature(
@@ -63,11 +69,11 @@ def generate_message_signature(
     if isinstance(message, str):
         message = message.encode()
 
-    # Convert the private key content to a RSAPrivateKey object
+    # Convert the private key content to an asymmetric private key type
     if isinstance(private_key, str):
         private_key = load_rsa_private_key(private_key)
 
-    # Sign the message using the RSAPrivateKey object
+    # Sign the message using the private key
     signature: bytes = private_key.sign(message, PKCS1v15(), SHA512())
 
     # Return the BASE64 encoded SHA512 signature


### PR DESCRIPTION
Add `global_key` argument to TransIP client `__init()__` method
to allow disabling of IP whitelisting for access token

Fixes #46