### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes in **python-transip** are documented below.
 
 ## [Unreleased]
+
+## [0.5.0] (2021-02-10)
 ### Added
 - The option to replace all existing nameservers of a single domain at once from the `transip.v6.objects.Domain.nameservers` service.
 - The option to list all colocations from the `transip.TransIP.colocations` service ([#24](https://github.com/roaldnefs/python-transip/issues/24)).
@@ -19,5 +21,6 @@ All notable changes in **python-transip** are documented below.
 - The option to update the content of a single DNS record from the `transip.v6.objects.Domain.dns` service, as well as from the `transip.v6.objects.DnsEntry` object.
 - The option to replace all existing DNS records of a single domain at once from the `transip.v6.objects.Domain.dns` service.
 
-[Unreleased]: https://github.com/roaldnefs/python-transip/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/roaldnefs/python-transip/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/roaldnefs/python-transip/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/roaldnefs/python-transip/compare/v0.3.0...v0.4.0

--- a/transip/__init__.py
+++ b/transip/__init__.py
@@ -30,7 +30,7 @@ from transip.utils import generate_message_signature, generate_nonce
 
 
 __title__ = "python-transip"
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __author__ = "Roald Nefs"
 __email__ = "info@roaldnefs.com"
 __copyright__ = "Copyright 2020-2021, Roald Nefs"


### PR DESCRIPTION
Bump version to **0.5.0**, this release included the following additions:
- The option to replace all existing nameservers of a single domain at once from the `transip.v6.objects.Domain.nameservers` service.
- The option to list all colocations from the `transip.TransIP.colocations` service ([#24](https://github.com/roaldnefs/python-transip/issues/24)).
- The option to retrieve a single colocation by name from the `transip.TransIP.colocations` service ([#24](https://github.com/roaldnefs/python-transip/issues/24)).
- The option to allow the access token to be used from all IP-addresses instead of only the whitelisted ones ([#46](https://github.com/roaldnefs/python-transip/issues/46)).
